### PR TITLE
FLEXY-4441 added kibana logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@emotion/jest": "^11.10.5",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
-    "@twilio/flex-ui": "2.0.2",
+    "@twilio/flex-ui": "2.1.1",
     "@types/jest": "^26.0.24",
     "@types/lodash": "4.14.182",
     "jest": "^26.0.20",

--- a/ui-src/package.json
+++ b/ui-src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flex-plugin-library-conference",
   "version": "1.0.0",
-  "pluginsLibraryUniqueName": "plibo-dialpad-addon-conference",
+  "id": "plibo-dialpad-addon-conference",
   "private": true,
   "scripts": {
     "prebuild": "rimraf build && npm run bootstrap",

--- a/ui-src/package.json
+++ b/ui-src/package.json
@@ -1,6 +1,7 @@
 {
   "name": "flex-plugin-library-conference",
   "version": "1.0.0",
+  "pluginsLibraryUniqueName": "plibo-dialpad-addon-conference",
   "private": true,
   "scripts": {
     "prebuild": "rimraf build && npm run bootstrap",

--- a/ui-src/package.json
+++ b/ui-src/package.json
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
-    "@twilio/flex-ui": "2.0.2",
+    "@twilio/flex-ui": "2.1.1",
     "@types/jest": "^26.0.20",
     "@types/react-redux": "^7.1.1",
     "@emotion/styled": "11.10.5"

--- a/ui-src/src/utils/ErrorManager.ts
+++ b/ui-src/src/utils/ErrorManager.ts
@@ -48,7 +48,7 @@ class ErrorManagerImpl {
     try {
       console.log(`Conference Plugin: ${error}\nType: ${error.content.type}\nContext:${error.content.context}`);
       const pluginError = new Flex.FlexError(error.message, {
-        plugin: { name: packageJSON.pluginsLibraryUniqueName, version: packageJSON.version },
+        plugin: { name: packageJSON.id, version: packageJSON.version },
         description: error.content.description,
       });
       if (flexManager?.reportErrorEvent) {

--- a/ui-src/src/utils/ErrorManager.ts
+++ b/ui-src/src/utils/ErrorManager.ts
@@ -1,5 +1,8 @@
 import * as Flex from '@twilio/flex-ui';
+import packageJSON from '../../package.json';
 import { ConferenceNotification } from '../flex-hooks/notifications/Conference';
+
+const flexManager = window?.Twilio?.Flex?.Manager?.getInstance();
 
 export enum FlexPluginErrorType {
   action = 'ActionFramework',
@@ -44,6 +47,13 @@ class ErrorManagerImpl {
   public processError(error: FlexPluginError, showNotification: boolean): FlexPluginError {
     try {
       console.log(`Conference Plugin: ${error}\nType: ${error.content.type}\nContext:${error.content.context}`);
+      const pluginError = new Flex.FlexError(error.message, {
+        plugin: { name: packageJSON.name, version: packageJSON.version },
+        description: error.content.description,
+      });
+      if (flexManager?.reportErrorEvent) {
+        flexManager.reportErrorEvent(pluginError);
+      }
       if (showNotification) {
         Flex.Notifications.showNotification(ConferenceNotification.ErrorConference, {
           error: error,

--- a/ui-src/src/utils/ErrorManager.ts
+++ b/ui-src/src/utils/ErrorManager.ts
@@ -17,7 +17,7 @@ export enum FlexErrorSeverity {
 
 export type FlexPluginErrorContents = {
   type?: FlexPluginErrorType | string;
-  wrappedError?: Error | string | unknown;
+  wrappedError?: unknown;
   context?: string;
   description?: string;
   severity?: FlexErrorSeverity;
@@ -35,8 +35,8 @@ export class FlexPluginError extends Error {
     super(message);
     this.content = {
       ...content,
-      type: content.type || 'ConferencePlugin',
-      severity: content.severity || FlexErrorSeverity.normal,
+      type: content.type ?? 'ConferencePlugin',
+      severity: content.severity ?? FlexErrorSeverity.normal,
     };
     this.time = new Date();
     Object.setPrototypeOf(this, FlexPluginError.prototype);

--- a/ui-src/src/utils/ErrorManager.ts
+++ b/ui-src/src/utils/ErrorManager.ts
@@ -48,7 +48,7 @@ class ErrorManagerImpl {
     try {
       console.log(`Conference Plugin: ${error}\nType: ${error.content.type}\nContext:${error.content.context}`);
       const pluginError = new Flex.FlexError(error.message, {
-        plugin: { name: packageJSON.name, version: packageJSON.version },
+        plugin: { name: packageJSON.pluginsLibraryUniqueName, version: packageJSON.version },
         description: error.content.description,
       });
       if (flexManager?.reportErrorEvent) {


### PR DESCRIPTION
## Description

JIRA: [FLEXY-?](https://issues.corp.twilio.com/browse/FLEXY-?)

- DESCRIPTION_OF_PR

## Test Plan

- DESCRIPTION_OF_TEST_PLAN

## Checklist

- [ ] Individual public Repo in Twilio Github.com
- [ ] Test the plugin against Flex UI 2.x for compatibility
- [ ] Create plugin specific CI/CD files
- [ ] Unit test for UI code and serverless code (80% coverage)
- [ ] setup.js should be mandatorily part of the serverless functions
- [ ] Telemetry - Make use of the manager.reportPluginInteraction() to send the event data to Kibana
- [ ] For logging, console.log/warn/error should be effectively used with enough contextual information (these will by default show up in debugger once enabled)
- [ ] Exception handling with degraded UX or information to UI along with serverless retry mechanism (for wherever applicable)
  - 5xx should be handled with retry mechanism (max of 3 attempts)
  - 4xx should be reported back to user saying "Please try after some time...."
- [ ] Details.md file to have content that needs to show up on PluginsLibrary frontend
- [ ] License file to be added in the repo
- [ ] Readme.md updated
- [ ] Plugin template should have a screeshot folder, which contains one image (1.gif) of 1280 x 720 resolution (16:9 aspect ratio).
- [ ] Snyk integration for security vulenrabilities (fix them if there are any)
- [ ] CodeCov integration for testing coverage
- [ ] E2E test suite for the entire plugin
- [ ] For E2E or any automated test, container components and user interactable child components must have ID attribute set.
